### PR TITLE
修正Open Sensor1 電池電量曲線

### DIFF
--- a/Sources/SesameSDK/Ble/SesameOS3/SesameBiometricDevice/Models/OpensensorMechStatus.swift
+++ b/Sources/SesameSDK/Ble/SesameOS3/SesameBiometricDevice/Models/OpensensorMechStatus.swift
@@ -25,7 +25,7 @@ struct OpensensorMechStatus: CHSesameProtocolMechStatus {
     
     func getBatteryPrecentage() -> Int { // [CHDeviceProtocol]共用電量計算曲線
         let voltage = getBatteryVoltage()
-        let blocks: [Float] = [5.820, 5.810, 5.755, 5.735, 5.665, 5.620, 5.585, 5.556, 5.550, 5.530, 5.450, 5.400, 5.320, 5.280, 5.225, 5.150]
+        let blocks: [Float] = [5.820, 5.810, 5.755, 5.735, 5.665, 5.620, 5.585, 5.556, 5.550, 5.50, 5.40, 5.20, 5.10, 5.0, 4.8, 4.6]
         let mapping: [Float] = [100.0, 95.0, 90.0, 85.0, 80.0, 70.0, 60.0, 50.0, 40.0, 32.0, 21.0, 13.0, 10.0, 7.0, 3.0, 0.0]
         if voltage >= blocks[0] {
             return Int(mapping[0])


### PR DESCRIPTION
This pull request updates the battery percentage calculation logic for the `OpensensorMechStatus` struct. The main change is a revision of the voltage "blocks" thresholds used to map battery voltage to percentage, which will affect how battery life is reported to users.

Battery calculation update:

* Updated the `blocks` array in `getBatteryPrecentage()` to use new voltage thresholds for mapping battery voltage to percentage, likely to provide more accurate or device-appropriate battery readings.