### PR TITLE
WiFi Module の FW 最新表示を追加 / 新增 WiFi Module 韌體最新版本顯示

### DIFF
--- a/SesameUI/SesameUI/Source/TabViewController/BaseViewController/CHBaseViewController.swift
+++ b/SesameUI/SesameUI/Source/TabViewController/BaseViewController/CHBaseViewController.swift
@@ -161,4 +161,45 @@ public class CHBaseViewController: UIViewController, CHRouteCoordinator {
         }
     }
 
+    /// Cloud OTA devices (e.g. WiFi Module 2) have no bundled DFU zip; compare against server `latestFwVer`.
+    func refreshCloudOTAVersionTag(
+        device: CHDevice,
+        setVersionStr: @escaping (String) -> Void,
+        setExclamationHidden: @escaping (Bool) -> Void
+    ) {
+        device.getVersionTag { result in
+            switch result {
+            case .success(let status):
+                let currentVersion = status.data
+                let latestVersion = device.stateInfo?.latestFwVer
+                let isNewest = latestVersion.map {
+                    currentVersion.contains($0) || $0.contains(currentVersion)
+                } ?? false
+                let versionText = "\(currentVersion)\(isNewest ? "co.candyhouse.sesame2.latest".localized : "")"
+                let hideExclamation = isNewest || latestVersion == nil
+
+                executeOnMainThread {
+                    setVersionStr(versionText)
+                    setExclamationHidden(hideExclamation)
+                }
+
+                CHDeviceWrapperManager.shared.updateCurrentFwVer(
+                    for: device.deviceId.uuidString,
+                    currentFwVer: currentVersion
+                ) {
+                    NotificationCenter.default.post(
+                        name: .firmwareVersionUpdated,
+                        object: nil,
+                        userInfo: [
+                            "deviceId": device.deviceId.uuidString
+                        ]
+                    )
+                }
+
+            case .failure(let error):
+                L.d("[refreshCloudOTAVersionTag]", error.errorDescription())
+            }
+        }
+    }
+
 }

--- a/SesameUI/SesameUI/Source/TabViewController/devices/WifiModule2/Setting/WifiModule2SettingViewController.swift
+++ b/SesameUI/SesameUI/Source/TabViewController/devices/WifiModule2/Setting/WifiModule2SettingViewController.swift
@@ -30,7 +30,7 @@ class WifiModule2SettingViewController: CHBaseViewController, UICollectionViewDe
     var uuidView: CHUIPlainSettingView!
     var versionView: CHUIPlainSettingView!
     var statusView: CHUIPlainSettingView!
-    var versionTag = ""
+    private var isVersionLoaded = false
     @IBOutlet var networkStatusView: UIView!
     @IBOutlet weak var networkStatusTitleLabel: UILabel! {
         didSet {
@@ -75,6 +75,7 @@ class WifiModule2SettingViewController: CHBaseViewController, UICollectionViewDe
     var wifiSSIDView: CHUIPlainSettingView!
     var wifiPasswordView: CHUIPlainSettingView!
     var wifiExclamationContainerView: UIView!
+    var versionExclamationContainerView: UIView!
     var sesameExclamationContainerView: UIView!
     
     var ssidScanViewController: WifiModule2SSIDScanViewController?
@@ -104,17 +105,7 @@ class WifiModule2SettingViewController: CHBaseViewController, UICollectionViewDe
         sesame2ListView.isScrollEnabled = false
         
         if wifiModule2.deviceStatus.loginStatus == .logined {
-            wifiModule2.getVersionTag() { result in
-                switch result {
-                case .success(let versionTag):
-                    executeOnMainThread {
-                        self.versionTag = versionTag.data
-                        self.versionView.value = versionTag.data
-                    }
-                case .failure(_):
-                    break
-                }
-            }
+            getVersionTag()
         }
         
         refreshControl.attributedTitle = NSAttributedString(string: "co.candyhouse.sesame2.PullToRefresh".localized)
@@ -202,6 +193,15 @@ class WifiModule2SettingViewController: CHBaseViewController, UICollectionViewDe
         }
         versionView.title = "co.candyhouse.sesame2.WM2OSUpdate".localized
         versionView.value = ""
+        versionExclamationContainerView = UIView(frame: .zero)
+        let versionExclamation = UIImageView(image: UIImage.SVGImage(named: "exclamation", fillColor: .lockRed))
+        versionExclamation.contentMode = .scaleAspectFit
+        versionExclamationContainerView.addSubview(versionExclamation)
+        versionView.appendViewToTitle(versionExclamationContainerView)
+        versionExclamation.autoLayoutWidth(20)
+        versionExclamation.autoLayoutHeight(20)
+        versionExclamation.autoPinCenterY()
+        versionExclamationContainerView.isHidden = true
         contentStackView.addArrangedSubview(versionView)
         contentStackView.addArrangedSubview(CHUISeperatorView(style: .thin))
         
@@ -369,10 +369,24 @@ class WifiModule2SettingViewController: CHBaseViewController, UICollectionViewDe
     @IBAction func networkStatusDidTapped(_ sender: Any) {
     }
     
+    private func getVersionTag() {
+        refreshCloudOTAVersionTag(
+            device: wifiModule2,
+            setVersionStr: { [weak self] text in
+                guard let self = self else { return }
+                self.isVersionLoaded = true
+                self.versionView.value = text
+            },
+            setExclamationHidden: { [weak self] isHidden in
+                self?.versionExclamationContainerView.isHidden = isHidden
+            }
+        )
+    }
+
     @objc func updateFirmware(_ button: UIButton) {
         let alertController = UIAlertController(title: "", message: "co.candyhouse.sesame2.WM2OSUpdate".localized, preferredStyle: .actionSheet)
         let ok = UIAlertAction(title: "co.candyhouse.sesame2.OK".localized, style: .default) { _ in
-            self.versionTag = ""
+            self.isVersionLoaded = false
             self.wifiModule2.updateFirmware { result in
                 if case let .failure(error) = result {
                     L.d(error.errorDescription())
@@ -490,20 +504,8 @@ extension WifiModule2SettingViewController: CHWifiModule2Delegate {
             device.connect() { _ in }
         }
         
-        if status.loginStatus == .logined {
-            if versionTag == "" {
-                wifiModule2.getVersionTag() { result in
-                    switch result {
-                    case .success(let versionTag):
-                        executeOnMainThread {
-                            self.versionTag = versionTag.data
-                            self.versionView.value = versionTag.data
-                        }
-                    case .failure(_):
-                        break
-                    }
-                }
-            }
+        if status.loginStatus == .logined, !isVersionLoaded {
+            getVersionTag()
         }
 
         executeOnMainThread {
@@ -532,6 +534,10 @@ extension WifiModule2SettingViewController: CHWifiModule2Delegate {
     func onOTAProgress(device: CHWifiModule2, percent: UInt8) {
         executeOnMainThread {
             self.versionView.value = "\(percent) %"
+            if percent >= 100 {
+                self.isVersionLoaded = false
+                self.getVersionTag()
+            }
         }
     }
     


### PR DESCRIPTION
## Summary / 概要 / 摘要

| 日本語 | 繁體中文（台灣） |
|--------|------------------|
| WiFi Module 2 の設定画面で、サーバーの `latestFwVer` と端末の FW バージョンを比較し、最新の場合は `(Latest)` を表示する | WiFi Module 2 設定頁面會比對伺服器 `latestFwVer` 與裝置韌體版本，若為最新版則顯示 `(Latest)` |
| 更新がある場合はバージョン行に赤い `!` を表示する | 若有可用更新，於版本列顯示紅色 `!` 提示 |
| クラウド OTA 向けに `refreshCloudOTAVersionTag()` を追加（内蔵 DFU zip がないデバイス用） | 新增 `refreshCloudOTAVersionTag()`，供無內建 DFU zip 的雲端 OTA 裝置使用 |
| OTA 完了（100%）後にバージョンを再取得する | OTA 完成（100%）後重新取得版本資訊 |
| `currentFwVer` を保存し、デバイスリストの更新バッジにも反映 | 儲存 `currentFwVer`，並反映至裝置列表的更新提示 |

## Test plan / テスト項目 / 測試項目

| 日本語 | 繁體中文（台灣） |
|--------|------------------|
| [ ] WiFi Module 2 設定を開き、FW バージョンが表示されること | [ ] 開啟 WiFi Module 2 設定，確認韌體版本有顯示 |
| [ ] サーバー `latestFwVer` と一致する場合、`(Latest)` が表示され `!` が出ないこと | [ ] 與伺服器 `latestFwVer` 一致時，顯示 `(Latest)` 且不出現 `!` |
| [ ] サーバー側が新しい場合、`!` が表示され `(Latest)` が出ないこと | [ ] 伺服器版本較新時，顯示 `!` 且不顯示 `(Latest)` |
| [ ] Software Update＆Restart 実行後、進捗 `%` 表示 → 完了後にバージョンが更新されること | [ ] 執行 Software Update＆Restart 後，顯示進度 `%`，完成後版本資訊會更新 |
| [ ] 設定画面を開いた後、デバイスリストの更新アイコンが更新されること | [ ] 進入設定頁後，裝置列表的更新圖示會同步更新 |

Made with [Cursor](https://cursor.com)