### PR TITLE
Fix blank Card/PIN/Fingerprint names from Android SDK / 修正 Android SDK 新增之生物辨識名稱空白問題

### DIFF
--- a/SesameUI/SesameUI/Source/TabViewController/devices/SesameBiometricDevice/Setting/FaceListVC .swift
+++ b/SesameUI/SesameUI/Source/TabViewController/devices/SesameBiometricDevice/Setting/FaceListVC .swift
@@ -218,7 +218,8 @@ class FaceListVC: CHBaseTableVC ,CHFaceDelegate, CHDeviceStatusDelegate{
     }
     func onFaceReceive(device: CHSesameConnector, id: String, name: String, type: UInt8) {
         executeOnMainThread {
-            self.faceList.insert(Face(id: id, name: "", nameUUID: name.noDashtoUUID()!.uuidString.lowercased()), at: 0)
+            let parsed = BiometricData.parseDeviceCredentialName(hexName: name)
+            self.faceList.insert(Face(id: id, name: parsed.name, nameUUID: parsed.nameUUID), at: 0)
             self.reloadTableView()
         }
 
@@ -247,7 +248,8 @@ class FaceListVC: CHBaseTableVC ,CHFaceDelegate, CHDeviceStatusDelegate{
     
     func onFaceChanged(device: CHSesameConnector, id: String, name: String, type: UInt8) {
         L.d("[FG][onFaceChanged] \(id):\(name)")
-        let face = Face(id: id, name: "", nameUUID: name.noDashtoUUID()!.uuidString.lowercased())
+        let parsed = BiometricData.parseDeviceCredentialName(hexName: name)
+        let face = Face(id: id, name: parsed.name, nameUUID: parsed.nameUUID)
         self.faceList.insert(face, at: 0)
         self.reloadTableView()
         guard let capable = device as? CHFaceCapable else {

--- a/SesameUI/SesameUI/Source/TabViewController/devices/SesameBiometricDevice/Setting/FingerPrintListVC.swift
+++ b/SesameUI/SesameUI/Source/TabViewController/devices/SesameBiometricDevice/Setting/FingerPrintListVC.swift
@@ -183,7 +183,7 @@ class FingerPrintListVC: CHBaseTableVC ,CHFingerPrintDelegate, CHDeviceStatusDel
                    }
                }
                ChangeValueDialog.show(nameText, title: "co.candyhouse.sesame2.EditName".localized) { name in
-                   if BiometricData.isUUIDv4(name: fingerprint.nameUUID) {
+                   if BiometricData.isServerSyncedName(fingerprint.nameUUID) {
                        renameToServer(name, fingerprint.nameUUID)
                    } else {
                        let uuid = UUID().uuidString.lowercased()
@@ -221,11 +221,8 @@ class FingerPrintListVC: CHBaseTableVC ,CHFingerPrintDelegate, CHDeviceStatusDel
     }
     func onFingerPrintReceive(device: CHDevice, id: String, hexName: String, type: UInt8) {
         executeOnMainThread {
-            if BiometricData.isUUIDv4(name: hexName) {
-                self.fingerPrints.insert(FingerPrint(id: id, name: "", nameUUID: hexName.noDashtoUUID()!.uuidString.lowercased()), at: 0)
-            } else {
-                self.fingerPrints.insert(FingerPrint(id: id, name: hexName, nameUUID: hexName), at: 0)
-            }
+            let parsed = BiometricData.parseDeviceCredentialName(hexName: hexName)
+            self.fingerPrints.insert(FingerPrint(id: id, name: parsed.name, nameUUID: parsed.nameUUID), at: 0)
             self.reloadTableView()
         }
 
@@ -254,10 +251,8 @@ class FingerPrintListVC: CHBaseTableVC ,CHFingerPrintDelegate, CHDeviceStatusDel
     
     func onFingerPrintChanged(device: CHDevice, id: String, hexName: String, type: UInt8) {
         L.d("[FG][onFingerPrintChanged] \(id):\(hexName)")
-        var fingerprint = FingerPrint(id: id, name: hexName, nameUUID: hexName)
-        if BiometricData.isUUIDv4(name: hexName) {
-            fingerprint = FingerPrint(id: id, name: "", nameUUID: hexName.noDashtoUUID()!.uuidString.lowercased())
-        }
+        let parsed = BiometricData.parseDeviceCredentialName(hexName: hexName)
+        let fingerprint = FingerPrint(id: id, name: parsed.name, nameUUID: parsed.nameUUID)
         self.fingerPrints.insert(fingerprint, at: 0)
         executeOnMainThread {
             self.reloadTableView()

--- a/SesameUI/SesameUI/Source/TabViewController/devices/SesameBiometricDevice/Setting/NFCCardVC.swift
+++ b/SesameUI/SesameUI/Source/TabViewController/devices/SesameBiometricDevice/Setting/NFCCardVC.swift
@@ -452,7 +452,7 @@ class NFCCardVC: CHBaseTableVC ,CHCardDelegate, CHDeviceStatusDelegate{
                 }
             }
             ChangeValueDialog.show(nameText, title: "co.candyhouse.sesame2.EditName".localized) { name in
-                if BiometricData.isUUIDv4(name: card.nameUUID) {
+                if BiometricData.isServerSyncedName(card.nameUUID) {
                     renameToServer(name, card.nameUUID)
                 } else {
                     let uuid = UUID().uuidString.lowercased()
@@ -490,11 +490,8 @@ class NFCCardVC: CHBaseTableVC ,CHCardDelegate, CHDeviceStatusDelegate{
     func onCardReceive(device: CHSesameConnector, id: String, hexName: String, type: UInt8) {
         executeOnMainThread {
             //接收卡片时，列表显示默认名称，name转为 nameUUID，用于获取后台真实的name
-            if BiometricData.isUUIDv4(name: hexName) {
-                self.mCardList.insert(SuiCard(id: id, name: "",type:type,nameUUID: hexName.noDashtoUUID()!.uuidString.lowercased()), at: 0)
-            } else {
-                self.mCardList.insert(SuiCard(id: id, name: hexName,type:type,nameUUID: hexName), at: 0)
-            }
+            let parsed = BiometricData.parseDeviceCredentialName(hexName: hexName)
+            self.mCardList.insert(SuiCard(id: id, name: parsed.name, type: type, nameUUID: parsed.nameUUID), at: 0)
             self.reloadTableView()
         }
     }
@@ -521,10 +518,8 @@ class NFCCardVC: CHBaseTableVC ,CHCardDelegate, CHDeviceStatusDelegate{
     }
 
     func onCardChanged(device: CHSesameConnector, id: String, hexName: String, type: UInt8) {
-        var card = SuiCard(id: id, name: hexName, type: type, nameUUID: hexName)
-        if BiometricData.isUUIDv4(name: hexName) {
-            card = SuiCard(id: id, name: "", type: type, nameUUID: hexName.noDashtoUUID()!.uuidString.lowercased())
-        }
+        let parsed = BiometricData.parseDeviceCredentialName(hexName: hexName)
+        var card = SuiCard(id: id, name: parsed.name, type: type, nameUUID: parsed.nameUUID)
         self.mCardList.insert(card, at: 0)
         executeOnMainThread {
             self.reloadTableView()

--- a/SesameUI/SesameUI/Source/TabViewController/devices/SesameBiometricDevice/Setting/PalmListVC.swift
+++ b/SesameUI/SesameUI/Source/TabViewController/devices/SesameBiometricDevice/Setting/PalmListVC.swift
@@ -221,7 +221,8 @@ class PalmListVC: CHBaseTableVC ,CHPalmDelegate, CHDeviceStatusDelegate{
     }
     func onPalmReceive(device: CHSesameConnector, id: String, name: String, type: UInt8) {
         executeOnMainThread {
-            self.palmList.insert(Palm(id: id, name: "", nameUUID: name.noDashtoUUID()!.uuidString.lowercased()), at: 0)
+            let parsed = BiometricData.parseDeviceCredentialName(hexName: name)
+            self.palmList.insert(Palm(id: id, name: parsed.name, nameUUID: parsed.nameUUID), at: 0)
             self.reloadTableView()
         }
 
@@ -251,7 +252,8 @@ class PalmListVC: CHBaseTableVC ,CHPalmDelegate, CHDeviceStatusDelegate{
     func onPalmChanged(device: CHSesameConnector, id: String, name: String, type: UInt8) {
         L.d("[FG][onPalmChanged] \(id):\(name)")
         executeOnMainThread {
-            let palm = Palm(id: id, name: "", nameUUID: name.noDashtoUUID()!.uuidString.lowercased())
+            let parsed = BiometricData.parseDeviceCredentialName(hexName: name)
+            let palm = Palm(id: id, name: parsed.name, nameUUID: parsed.nameUUID)
             self.palmList.insert(palm, at: 0)
             self.reloadTableView()
             guard let capable = device as? CHPalmCapable else {

--- a/SesameUI/SesameUI/Source/TabViewController/devices/SesameBiometricDevice/Setting/PassCodeVC.swift
+++ b/SesameUI/SesameUI/Source/TabViewController/devices/SesameBiometricDevice/Setting/PassCodeVC.swift
@@ -391,7 +391,7 @@ class PassCodeVC: CHBaseTableVC ,CHPassCodeDelegate, CHDeviceStatusDelegate{
                 }
             }
             ChangeValueDialog.show(nameText, title: "co.candyhouse.sesame2.EditName".localized) { name in
-                if BiometricData.isUUIDv4(name: passCode.nameUUID) {
+                if BiometricData.isServerSyncedName(passCode.nameUUID) {
                   renameToServer(name, passCode.nameUUID)
                 } else {
                     let uuid = UUID().uuidString.lowercased()
@@ -426,11 +426,8 @@ class PassCodeVC: CHBaseTableVC ,CHPassCodeDelegate, CHDeviceStatusDelegate{
     }
     func onPassCodeReceive(device: CHSesameConnector, id: String, hexName: String, type: UInt8) {
         executeOnMainThread {
-            if BiometricData.isUUIDv4(name: hexName) {
-                self.mPassCodeList.insert(KeyboardPassCode(id: id, name: "", nameUUID: hexName.noDashtoUUID()!.uuidString.lowercased()), at: 0)
-            } else {
-                self.mPassCodeList.insert(KeyboardPassCode(id: id, name: hexName, nameUUID: hexName), at: 0)
-            }
+            let parsed = BiometricData.parseDeviceCredentialName(hexName: hexName)
+            self.mPassCodeList.insert(KeyboardPassCode(id: id, name: parsed.name, nameUUID: parsed.nameUUID), at: 0)
             self.reloadTableView()
         }
     }
@@ -458,10 +455,8 @@ class PassCodeVC: CHBaseTableVC ,CHPassCodeDelegate, CHDeviceStatusDelegate{
 
     func onPassCodeChanged(device: CHSesameConnector, id: String, hexName: String, type: UInt8) {
         executeOnMainThread {
-            var keyboardPassCode = KeyboardPassCode(id: id, name: hexName, nameUUID: hexName)
-            if BiometricData.isUUIDv4(name: hexName) {
-                keyboardPassCode = KeyboardPassCode(id: id, name: "", nameUUID: hexName.noDashtoUUID()!.uuidString.lowercased())
-            }
+            let parsed = BiometricData.parseDeviceCredentialName(hexName: hexName)
+            let keyboardPassCode = KeyboardPassCode(id: id, name: parsed.name, nameUUID: parsed.nameUUID)
             self.mPassCodeList.insert(keyboardPassCode, at: 0)
             self.reloadTableView()
             guard let capable = device as? CHPassCodeCapable else {

--- a/Sources/SesameSDK/Ble/SesameOS3/SesameBiometricDevice/Capabilities/Authentication/Service/CHServerCapableHandler.swift
+++ b/Sources/SesameSDK/Ble/SesameOS3/SesameBiometricDevice/Capabilities/Authentication/Service/CHServerCapableHandler.swift
@@ -74,7 +74,91 @@ public struct BiometricData: Codable {
             guard let name = dict["name"] as? String else {
                 return BiometricData(credentialId: "", nameUUID: "", type: "", name: "")
             }
-            return BiometricData(credentialId: credentialId, nameUUID: nameUUID, type: type, name: name)
+            let normalizedNameUUID = normalizedNameUUID(from: nameUUID) ?? nameUUID.lowercased()
+            return BiometricData(credentialId: credentialId, nameUUID: normalizedNameUUID, type: type, name: name)
+        }
+    }
+
+    /// Parsed name fields from a credential stored on the device.
+    public struct DeviceCredentialName {
+        public let name: String
+        public let nameUUID: String
+    }
+
+    /// True when the device stores a UUID reference instead of an inline UTF-8 name.
+    public static func isServerSyncedName(_ hexName: String?) -> Bool {
+        guard let hexName = hexName, !hexName.isEmpty else { return false }
+        if UUID(uuidString: hexName) != nil { return true }
+        return isUUIDv4(name: hexName)
+    }
+
+    /// Normalize UUID strings from device / server / Android SDK into lowercase dashed form.
+    public static func normalizedNameUUID(from hexName: String) -> String? {
+        let trimmed = hexName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        if let uuid = UUID(uuidString: trimmed) {
+            return uuid.uuidString.lowercased()
+        }
+        let hexOnly = trimmed.replacingOccurrences(of: "-", with: "")
+        guard hexOnly.count == 32, isUUIDv4(name: hexOnly) else { return nil }
+        return hexOnly.noDashtoUUID()?.uuidString.lowercased()
+    }
+
+    public static func parseDeviceCredentialName(hexName: String) -> DeviceCredentialName {
+        if isServerSyncedName(hexName), let nameUUID = normalizedNameUUID(from: hexName) {
+            return DeviceCredentialName(name: "", nameUUID: nameUUID)
+        }
+        return DeviceCredentialName(name: hexName, nameUUID: hexName)
+    }
+
+    public func resolvedName(fallback: String) -> String {
+        name.isEmpty ? fallback : name
+    }
+
+    static func mergeServerResolvedNames(local: [BiometricData], server: [BiometricData]) -> [BiometricData] {
+        server.map { serverItem in
+            let normalizedServerUUID = normalizedNameUUID(from: serverItem.nameUUID) ?? serverItem.nameUUID.lowercased()
+            if !serverItem.name.isEmpty {
+                return BiometricData(
+                    credentialId: serverItem.credentialId,
+                    nameUUID: normalizedServerUUID,
+                    type: serverItem.type,
+                    name: serverItem.name
+                )
+            }
+
+            let localMatch = local.first {
+                $0.credentialId.caseInsensitiveCompare(serverItem.credentialId) == .orderedSame
+            }
+            if let localName = localMatch?.name, !localName.isEmpty {
+                return BiometricData(
+                    credentialId: serverItem.credentialId,
+                    nameUUID: normalizedServerUUID,
+                    type: serverItem.type,
+                    name: localName
+                )
+            }
+
+            let localUUIDMatch = local.first { item in
+                guard !item.name.isEmpty,
+                      let localUUID = normalizedNameUUID(from: item.nameUUID) else { return false }
+                return localUUID == normalizedServerUUID
+            }
+            if let localName = localUUIDMatch?.name {
+                return BiometricData(
+                    credentialId: serverItem.credentialId,
+                    nameUUID: normalizedServerUUID,
+                    type: serverItem.type,
+                    name: localName
+                )
+            }
+
+            return BiometricData(
+                credentialId: serverItem.credentialId,
+                nameUUID: normalizedServerUUID,
+                type: serverItem.type,
+                name: serverItem.name
+            )
         }
     }
     
@@ -121,7 +205,8 @@ extension CHServerCapableHandler {
                    let itemsDict = jsonObj["data"] as? [String: Any],
                     let itemArys = itemsDict["items"] as? [[String: Any]] {
                     let items = BiometricData.toBiometricDatas(itemArys)
-                    result(.success(.init(input: items)))
+                    let merged = BiometricData.mergeServerResolvedNames(local: data.items, server: items)
+                    result(.success(.init(input: merged)))
                 } else {
                     result(.failure(NSError.parseError))
                 }


### PR DESCRIPTION
Fixes #61

## Summary / 概要 / 摘要

| 日本語 | 繁體中文（台灣） |
|--------|------------------|
| Android SDK で追加した Card / PIN / Fingerprint の名前が iOS で空白になる問題を調査・修正 | 修正 Android SDK 新增 Card / PIN / Fingerprint 後，iOS 端名稱顯示空白的問題 |
| デバイス上の UUID 参照名を dashed / 32hex 両対応で正規化 | 正規化裝置上的 UUID 參照名稱，支援 dashed 與 32 字元 hex 兩種格式 |
| `postAuthenticationData` 後にサーバーが空名を返してもローカル名を失わないよう merge | `postAuthenticationData` 後若伺服器回傳空名稱，合併結果時保留本地名稱 |
| Card / PIN / Fingerprint / Face / Palm フローで共通パーサーを使用 | Card / PIN / Fingerprint / Face / Palm 流程共用同一解析邏輯 |

## Background / 背景 / 背景說明

| 日本語 | 繁體中文（台灣） |
|--------|------------------|
| 認証情報の名前は「デバイス inline」または「UUID + サーバー保存」の 2 方式 | 認證資料名稱分為「裝置 inline」或「UUID + 伺服器儲存」兩種 |
| Android が dashed UUID を書き込むと、旧 iOS の `noDashtoUUID()` だけでは正しく解決できない可能性 | Android 寫入 dashed UUID 時，舊版 iOS 僅用 `noDashtoUUID()` 可能無法正確解析 |
| Android 側でサーバー同期が無い場合は iOS だけでは完全解決できない点も Issue に記載 | 若 Android 未同步名稱至伺服器，僅 iOS 修正無法完全解決，已於 Issue 說明 |

## Test plan / テスト項目 / 測試項目

| 日本語 | 繁體中文（台灣） |
|--------|------------------|
| [ ] Android SDK で Card / PIN / Fingerprint を追加 | [ ] 使用 Android SDK 新增 Card / PIN / Fingerprint |
| [ ] 同一アカウントで iOS Demo App から一覧取得 | [ ] 以同一帳號在 iOS Demo App 讀取列表 |
| [ ] 名前が表示される（サーバーに名前がある場合） | [ ] 名稱可正常顯示（伺服器已有名稱時） |
| [ ] dashed UUID / 32hex UUID どちらでも `nameUUID` が lowercase dashed に正規化される | [ ] dashed UUID / 32hex UUID 皆能正規化為 lowercase dashed `nameUUID` |
| [ ] サーバー名が空でも inline 名が消えない | [ ] 伺服器名稱為空時，inline 名稱不會被覆蓋消失 |


Made with [Cursor](https://cursor.com)