### PR TITLE
Document public Web API 500 troubleshooting (Issue #35) / 公開 Web API 500 エラー切り分けドキュメント

### DIFF
--- a/README.jp.md
+++ b/README.jp.md
@@ -22,6 +22,8 @@
 
 ### 1. プロジェクトの依存関係
 
+- 公開 Web API（`X-API-KEY`）で 500 エラーが出る場合 → [public-web-api-troubleshooting.ja.md](./doc/public-web-api-troubleshooting.ja.md)（Issue #35 関連）
+
 - [Sesame 5] :このオブジェクトの例は、Sesame5およびSesame5 Pro製品に適用されます
 - [Sesame Bike 2] :このオブジェクトの例は、Sesame Bike 2製品に適用されます
 - [Sesame WiFi Module 2]:このオブジェクトの例は、Sesame WiFi Module 2 製品に適用されます

--- a/Sources/SesameSDK/Server/CHAPIClient+biz.swift
+++ b/Sources/SesameSDK/Server/CHAPIClient+biz.swift
@@ -244,6 +244,10 @@ public extension CHAPIClient {
     
     // MARK: - IoT
     /// 获取设备影子数据 (watchOS)
+    ///
+    /// Uses the authenticated SDK route `/device/v1/sesame2/{deviceId}` (Cognito),
+    /// not the public Web API `GET https://app.candyhouse.co/api/sesame2/{UUID}` (`X-API-KEY`).
+    /// For public Web API 500 errors, see `doc/public-web-api-troubleshooting.ja.md`.
     func getCHDeviceShadow(deviceId: String, result: @escaping CHResult<Data>) {
         API(request: .init(.get, "/device/v1/sesame2/\(deviceId)")) { apiResult in
             switch apiResult {

--- a/doc/public-web-api-troubleshooting.ja.md
+++ b/doc/public-web-api-troubleshooting.ja.md
@@ -1,0 +1,47 @@
+# 公開 Web API トラブルシュート（Issue #35 関連）
+
+外部コントリビュータ視点でのメモ。CANDY-HOUSE 公式サポートの代替ではありません。
+
+## 2 種類の API がある
+
+| 種別 | 例 | 認証 | このリポジトリ |
+|------|-----|------|----------------|
+| **公開 Web API** | `GET https://app.candyhouse.co/api/sesame2/{UUID}` | `X-API-KEY` ヘッダ | **実装なし**（[SesameAPI ドキュメント](https://doc.candyhouse.co/ja/SesameAPI) 参照） |
+| **SDK 内部 API** | `GET /prod/device/v1/sesame2/{UUID}` | Cognito（アプリログイン） | `CHAPIClient.getCHDeviceShadow` 等 |
+
+Issue #35 の `{"message": "Internal server error"}` は **公開 Web API 側** の HTTP 500 です。  
+iOS SDK の BLE / IoT コードを変更しても、この 500 は直接は直りません。
+
+## Sesame 3 とパス名
+
+製品名が Sesame 3 でも、公開 API のパスは **`/api/sesame2/{UUID}`** のままです（製品名と API 名が一致しないだけ）。
+
+## 500 になる典型パターン（切り分け）
+
+公式ドキュメントおよび SDK の IoT 実装から推測される前提条件:
+
+1. **デバイスオーナー** の API キーを使っている
+2. **WiFi Module（旧 WiFi Access Point）** が Sesame とペアリング済み
+3. WiFi Module が **Wi-Fi / クラウド（IoT）に接続** している
+4. Sesame 公式アプリで **Integration（API 連携）が ON**
+
+上記が満たされないと、サーバーがデバイス shadow を取得できず 500 になることがあります（401/404 ではなく 500 になるケース）。
+
+## 切り分け手順
+
+1. 公式 Sesame アプリで、対象デバイスの **リモート状態表示・解錠** ができるか確認
+2. WiFi Module 設定で **Network / IoT** が接続済みか確認
+3. 同じ API キー・UUID で `GET /api/sesame2/{UUID}` を再実行
+4. 401 → API キー / 権限、404 → UUID 誤り、**500 が継続** → サーバー側調査が必要
+
+## SDK 側で確認できること
+
+- リモート状態は AWS Device Shadow 経由（`CHIoTManager`, `CHDeviceShadow`）で扱われる
+- WiFi Module ↔ Sesame の BLE リンク（shadow の `wm2s`）が切れていると、リモート操作が不安定になる（Issue #40 も参照）
+
+## サーバー側調査が必要な場合
+
+500 が前提条件を満たしても継続する場合:
+
+- [Candy House サポート](mailto:sesame@candyhouse.co) へ、**発生時刻・UUID（マスク可）・HTTP ステータス** を添えて問い合わせ
+- GitHub Issue: [#35](https://github.com/CANDY-HOUSE/SesameSDK_iOS_with_DemoApp/issues/35)


### PR DESCRIPTION
Related to #35

## Summary / 概要 / 摘要

| 日本語 | 繁體中文（台灣） |
|--------|------------------|
| Issue #35: 公開 Web API `GET /api/sesame2/{UUID}` の 500 エラーについて、SDK リポジトリでできる切り分けを文書化 | 針對 Issue #35：公開 Web API `GET /api/sesame2/{UUID}` 回傳 500，於 SDK repo 補充可做的排查說明 |
| 公開 Web API（`X-API-KEY`）と SDK 内部 API（Cognito `/device/v1/...`）は別物であることを明記 | 明確區分公開 Web API（`X-API-KEY`）與 SDK 內部 API（Cognito `/device/v1/...`） |
| Sesame 3 でも `/api/sesame2/` パスは正しい | Sesame 3 仍使用 `/api/sesame2/` 路徑 |
| 500 自体はサーバー側問題であり、SDK コード変更では直接修正できない点を記載 | 500 為伺服器端問題，無法透過 SDK 程式碼直接修復 |

## Changes / 変更内容 / 變更內容

| 日本語 | 繁體中文（台灣） |
|--------|------------------|
| `doc/public-web-api-troubleshooting.ja.md` 追加 | 新增 `doc/public-web-api-troubleshooting.ja.md` |
| `README.jp.md` からリンク | 從 `README.jp.md` 加入連結 |
| `getCHDeviceShadow` に公開 API との違いをコメント | 於 `getCHDeviceShadow` 註解標明與公開 API 的差異 |

## Note / 注意 / 注意事項

| 日本語 | 繁體中文（台灣） |
|--------|------------------|
| 本 PR はサーバー 500 の修正ではなく、誤解を減らすドキュメント追加です | 本 PR 非修復伺服器 500，而是減少混淆的文件補充 |
| 500 が継続する場合は Candy House サポートへの問い合わせが必要 | 若 500 持續，仍需聯絡 Candy House 支援 |


Made with [Cursor](https://cursor.com)