### PR TITLE
fix: 履歴ログの時刻表示を24時間表記に統一 / 統一歷史紀錄時間為 24 小時制

### DIFF
--- a/SesameUI/SesameUI/Source/TabViewController/devices/Sesame2/History/SSM2HistoryCellViewModel.swift
+++ b/SesameUI/SesameUI/Source/TabViewController/devices/Sesame2/History/SSM2HistoryCellViewModel.swift
@@ -22,11 +22,11 @@ public final class Sesame2HistoryCellViewModel: ViewModel {
     public func timeLabelText() -> String {
         let date = Date(timeIntervalSince1970: TimeInterval(history.timeStamp))
         let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "HH:mm:ss a"
+        // 24時間表記（HH + AM/PM の併用は ja_JP で "AM 8:45:43" のように不自然になる）
+        // 24 小時制（HH 與 AM/PM 併用時，ja_JP 會顯示成 "AM 8:45:43" 等不自然格式）
+        dateFormatter.dateFormat = "HH:mm:ss"
         dateFormatter.locale = Locale(identifier: "ja_JP")
-        dateFormatter.amSymbol = "AM"
-        dateFormatter.pmSymbol = "PM"
-        return "\(dateFormatter.string(from: date))"
+        return dateFormatter.string(from: date)
     }
     
     public var eventImage: String {

--- a/SesameUI/SesameUI/Source/TabViewController/devices/SesameBikeLock/History/BicycleLockHistoryModel.swift
+++ b/SesameUI/SesameUI/Source/TabViewController/devices/SesameBikeLock/History/BicycleLockHistoryModel.swift
@@ -101,11 +101,11 @@ extension BikeLockHistory {
     
     var dateTime: String {
         let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "HH:mm:ss a"
+        // 24時間表記（HH + AM/PM の併用は ja_JP で "AM 8:45:43" のように不自然になる）
+        // 24 小時制（HH 與 AM/PM 併用時，ja_JP 會顯示成 "AM 8:45:43" 等不自然格式）
+        dateFormatter.dateFormat = "HH:mm:ss"
         dateFormatter.locale = Locale(identifier: "ja_JP")
-        dateFormatter.amSymbol = "AM"
-        dateFormatter.pmSymbol = "PM"
-        return "\(dateFormatter.string(from: date))"
+        return dateFormatter.string(from: date)
     }
     
     


### PR DESCRIPTION
## Summary / 概要

### 日本語
Sesame の履歴ログで時刻が `AM 8:45:43` のように AM/PM が先頭に付く不自然な表示になっていた問題を修正しました。

**原因:** `DateFormatter` のフォーマット `"HH:mm:ss a"` が 24 時間表記（`HH`）と AM/PM（`a`）を併用しており、`ja_JP` ロケールでは AM/PM が時刻の前に出力されていました。

**対応:** フォーマットを `"HH:mm:ss"` の 24 時間表記のみに変更し、不要な `amSymbol` / `pmSymbol` を削除しました。

**変更ファイル:**
- `SesameUI/.../SSM2HistoryCellViewModel.swift`（Sesame2 履歴）
- `SesameUI/.../BicycleLockHistoryModel.swift`（Bike Lock 履歴）

**表示例:**
- Before: `AM 8:45:43`
- After: `08:45:43`

### 繁體中文
Sesame 歷史紀錄的時間曾顯示為 `AM 8:45:43` 這類 AM/PM 置於前方的格式，看起來不自然。本次 PR 修正此問題。

**原因:** `DateFormatter` 使用 `"HH:mm:ss a"`，同時混用 24 小時制（`HH`）與 AM/PM（`a`）；在 `ja_JP` locale 下，AM/PM 會被輸出到時間前面。

**修正:** 改為僅使用 `"HH:mm:ss"` 的 24 小時制，並移除不必要的 `amSymbol` / `pmSymbol`。

**變更檔案:**
- `SesameUI/.../SSM2HistoryCellViewModel.swift`（Sesame2 歷史紀錄）
- `SesameUI/.../BicycleLockHistoryModel.swift`（Bike Lock 歷史紀錄）

**顯示範例:**
- 修正前：`AM 8:45:43`
- 修正後：`08:45:43`

## Test plan / テスト計画 / 測試計畫

### 日本語
- [ ] Sesame2 の履歴画面を開き、時刻が `HH:mm:ss` 形式（例: `08:45:43`）で表示されること
- [ ] AM/PM が表示されないこと
- [ ] Bike Lock の履歴画面でも同様に確認すること

### 繁體中文
- [ ] 開啟 Sesame2 歷史紀錄畫面，確認時間以 `HH:mm:ss` 格式顯示（例如 `08:45:43`）
- [ ] 確認不再顯示 AM/PM
- [ ] 在 Bike Lock 歷史紀錄畫面做相同確認


Made with [Cursor](https://cursor.com)