### PR TITLE
fix: バッテリー残量が古い値のまま表示される問題を修正

### DIFF
--- a/SesameUI/SesameUI/Source/TabViewController/devices/SesameDeviceListViewController.swift
+++ b/SesameUI/SesameUI/Source/TabViewController/devices/SesameDeviceListViewController.swift
@@ -430,6 +430,7 @@ class SesameDeviceListViewController: CHBaseViewController {
                     left.compare(right)
                 }
                 completion?(self.allDevices)
+                self.refreshBatteryFromShadowIfNeeded(for: self.allDevices)
                 // 如果有搜索词，重新过滤
                 if !self.lastSearchQuery.isEmpty {
                     self.performSearch(query: self.lastSearchQuery)
@@ -448,6 +449,16 @@ class SesameDeviceListViewController: CHBaseViewController {
                     self.isInitialLoading = false
                 }
             }
+        }
+    }
+
+    private func refreshBatteryFromShadowIfNeeded(for devices: [CHDevice]) {
+        for device in devices {
+            guard device.isLockDevice,
+                  let lock = device as? CHSesameLock else {
+                continue
+            }
+            lock.refreshBatteryFromShadow { _ in }
         }
     }
     

--- a/Sources/SesameSDK/Ble/CHDevice.swift
+++ b/Sources/SesameSDK/Ble/CHDevice.swift
@@ -258,6 +258,29 @@ public protocol CHSesameLock: CHDevice {
 }
 
 public extension CHSesameLock {
+    /// BLE 未ログインかつ WiFi モジュール経由でオンラインのとき、Shadow からバッテリー残量を更新する。
+    func refreshBatteryFromShadow(result: @escaping CHResult<CHEmpty>) {
+        CHIoTManager.shared.getCHDeviceShadow(self) { shadowResult in
+            switch shadowResult {
+            case .success(let shadow):
+                self.applyShadowBatteryPercentageIfNeeded(shadow)
+                result(.success(.init(input: .init())))
+            case .failure(let error):
+                result(.failure(error))
+            }
+        }
+    }
+
+    func applyShadowBatteryPercentageIfNeeded(_ shadow: CHDeviceShadow) {
+        let isConnectedByWM2 = shadow.data.wifiModule2s?.contains(where: { $0.isConnected == true }) ?? false
+        guard isConnectedByWM2,
+              deviceStatus.loginStatus == .unlogined,
+              let percentage = shadow.data.batteryPercentage else {
+            return
+        }
+        (self as? CHBaseDevice)?.notifyBatteryPercentageChanged(percentage: percentage)
+    }
+
 #if os(watchOS)
     func getSesameLockStatus(result: @escaping CHResult<CHEmpty>) {
         CHIoTManager.shared.getCHDeviceShadow(self) { shadowResult in
@@ -276,7 +299,7 @@ public extension CHSesameLock {
                         if(isConnectedByWM2){
                             if( self.deviceStatus.loginStatus == .unlogined){
                                 self.mechStatus = mechStatus
-                                (self as? CHBaseDevice)?.notifyBatteryPercentageChanged(percentage: shadow.data.batteryPercentage ?? 0)
+                                self.applyShadowBatteryPercentageIfNeeded(shadow)
                             }
                         }
                     }
@@ -286,7 +309,7 @@ public extension CHSesameLock {
                         if(isConnectedByWM2){
                             if( self.deviceStatus.loginStatus == .unlogined){
                                 self.mechStatus = mechStatus
-                                (self as? CHBaseDevice)?.notifyBatteryPercentageChanged(percentage: shadow.data.batteryPercentage ?? 0)
+                                self.applyShadowBatteryPercentageIfNeeded(shadow)
                             }
                         }
                     }
@@ -296,7 +319,7 @@ public extension CHSesameLock {
                             if (isConnectedByWM2) {
                                 if( self.deviceStatus.loginStatus == .unlogined){
                                     self.mechStatus = mechStatus
-                                    (self as? CHBaseDevice)?.notifyBatteryPercentageChanged(percentage: shadow.data.batteryPercentage ?? 0)
+                                    self.applyShadowBatteryPercentageIfNeeded(shadow)
                                 }
                             }
                         }

--- a/Sources/SesameSDK/Ble/SesameOS3/CHSesameOS3LockBase.swift
+++ b/Sources/SesameSDK/Ble/SesameOS3/CHSesameOS3LockBase.swift
@@ -42,7 +42,11 @@ class CHSesameOS3LockBase: CHSesameOS3, CHDeviceUtil, CHSesameLock {
 
         switch itemCode {
         case .SSM3_ITEM_CODE_BATTERY_VOLTAGE:
-            postBatteryData(data.toHexString()) { _ in }
+            postBatteryData(data.toHexString()) { res in
+                if case .success(let resp) = res {
+                    self.notifyBatteryPercentageChanged(percentage: resp.data)
+                }
+            }
 
         case .SSM3_ITEM_CODE_BLE_TX_POWER_SETTING:
             guard let value = data.first else { return }

--- a/Sources/SesameSDK/Ble/SesameOS3/SesameBiometricDevice/Devices/BaseDevice/CHSesameBiometricDeviceImpl+Settings.swift
+++ b/Sources/SesameSDK/Ble/SesameOS3/SesameBiometricDevice/Devices/BaseDevice/CHSesameBiometricDeviceImpl+Settings.swift
@@ -24,7 +24,11 @@ extension CHSesameBiometricDeviceImpl {
             }
 
         case .SSM3_ITEM_CODE_BATTERY_VOLTAGE:
-            postBatteryData(payload.toHexString()) { _ in }
+            postBatteryData(payload.toHexString()) { res in
+                if case .success(let resp) = res {
+                    self.notifyBatteryPercentageChanged(percentage: resp.data)
+                }
+            }
 
         case .pubKeySesame:
             handle = true

--- a/Sources/SesameSDK/Server/CHAPIClient+biz.swift
+++ b/Sources/SesameSDK/Server/CHAPIClient+biz.swift
@@ -284,6 +284,7 @@ public extension CHAPIClient {
                 guard let data = data,
                       let jsonDict = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                       let batteryPercentage = jsonDict["batteryPercentage"] as? Int else {
+                    result(.failure(NSError(domain: "SesameSDK", code: 0, userInfo: [NSLocalizedDescriptionKey: "Invalid battery response"])))
                     return
                 }
                 result(.success(.init(input: batteryPercentage)))


### PR DESCRIPTION
## Summary

- `SSM3_ITEM_CODE_BATTERY_VOLTAGE` 受信時に `postBatteryData` の結果を `notifyBatteryPercentageChanged` へ渡すよう修正（SesameOS3 / Biometric 共通）
- iOS でも Shadow からバッテリー残量を更新できる `refreshBatteryFromShadow` を SDK に追加
- Demo App のデバイス一覧読み込み時に Shadow バッテリー更新を呼び出し（BLE 未接続・WM2 オンライン時）
- `postBatteryData` のレスポンスパース失敗時に黙って無視せずエラーを返すよう修正

## 背景

バッテリー残量は BLE の生電圧をサーバー API で % 換算して表示する設計だが、以下の抜けにより一度キャッシュされた値（例: 100%）が更新されないケースがあった。

1. バッテリー電圧専用イベントで API 結果を捨てていた
2. Shadow からのバッテリー取得が watchOS 専用だった

## Test plan

- [ ] Sesame 5 を WM2 経由でオンライン・BLE 未接続の状態でデバイス一覧を開き、バッテリー表示が Shadow の値に更新されること
- [ ] BLE 接続時に `mechStatus` / `BATTERY_VOLTAGE` イベントでバッテリー表示が更新されること
- [ ] 電池を消耗させたデバイスで表示が 100% 以外に変わること（実際の残量による）


Made with [Cursor](https://cursor.com)